### PR TITLE
Concurrencia na comunicação servidor-peers

### DIFF
--- a/version/v1.0/Peer_T.py
+++ b/version/v1.0/Peer_T.py
@@ -5,115 +5,120 @@ import secrets
 local_ip = socket.gethostbyname(socket.gethostname())
 serverIP = socket.gethostbyname("serverIP")
 UDP_PORT = 8000
+TCP_PORT = 5000
 
 def waitServerRequest():
-        port = 5000
 
-        print("*** Peer ("+local_ip +
-              ") ***\n (TCP) Waiting Server request on port "+str(port)+" ...")
-        socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        socket_TCP.bind((local_ip, port))
-        socket_TCP.listen(1)
-        connection, address = socket_TCP.accept()
-        print("Connected from "+str(address))
-        while True:
-            serverRequest = connection.recv(1024)
-            if not serverRequest:
-                break
-            return serverRequest
+		print("*** Peer ("+local_ip +
+			  ") ***\n (TCP) Waiting Server request on port "+str(TCP_PORT)+" ...")
+		
+		
+		print("Connected from "+str(address))
+		while True:
+			serverRequest = connection.recv(1024)
+			if not serverRequest:
+				break
+			return serverRequest
 
 def processRequest(request):
-        # |ID| TESTE | PeerDestino | Opcional
-        requestFields = request.split()
-        id = requestFields[0]
+		# |ID| TESTE | PeerDestino | Opcional
+		requestFields = request.split()
+		id = requestFields[0]
 
-        if id == "0":
-            teste = requestFields[1]
-            if teste == "1":  # Substituir por SWITCH c/ todos os testes
-                getLatencia(requestFields)
-            elif teste == "2":
-                getLostPackets(requestFields)
+		if id == "0":
+			teste = requestFields[1]
+			if teste == "1":  # Substituir por SWITCH c/ todos os testes
+				getLatencia(requestFields)
+			elif teste == "2":
+				getLostPackets(requestFields)
 
 def getLatencia(requestFields):
-        destinationIP = requestFields[2]
-        # Elapsed > monitoringInterval => Timeout   if( media = 0 => resultado = ERROR ) else{ media > 0 => resultado = media}
-        monitoringInterval = int(requestFields[3])
-        start_timer = time.time()
-        if destinationIP == local_ip:
-            waitUDP_message(1, monitoringInterval)
-        else:
-            counter = 0
-            while (time.time() <= start_timer + monitoringInterval):
-                message = (str(counter) + " ").encode()
-                sendUDP_message(message, destinationIP)
-                counter = counter + 1
-            print("Finished ...")
+		destinationIP = requestFields[2]
+		# Elapsed > monitoringInterval => Timeout   if( media = 0 => resultado = ERROR ) else{ media > 0 => resultado = media}
+		monitoringInterval = int(requestFields[3])
+		start_timer = time.time()
+		if destinationIP == local_ip:
+			waitUDP_message(1, monitoringInterval)
+		else:
+			counter = 0
+			while (time.time() <= start_timer + monitoringInterval):
+				message = (str(counter) + " ").encode()
+				sendUDP_message(message, destinationIP)
+				counter = counter + 1
+			print("Finished ...")
 
 def getLostPackets(requestFields):
-        destinationIP = requestFields[2]
-        nPackets = int(requestFields[3])
-        start_timer = time.time()
-        if destinationIP == local_ip:
-            waitUDP_message(2, 5)
-        else:
-            counter = 0
-            while counter < nPackets:
-                data = str(secrets.token_bytes(1020))
-                data = data.replace(" ", "-")				
-                message = ((str(counter) + " ")+data).encode()
-                sendUDP_message(message, destinationIP)
-                counter = counter + 1
-            print("Finished ...")
+		destinationIP = requestFields[2]
+		nPackets = int(requestFields[3])
+		start_timer = time.time()
+		if destinationIP == local_ip:
+			waitUDP_message(2, 5)
+		else:
+			counter = 0
+			while counter < nPackets:
+				data = str(secrets.token_bytes(1020))
+				data = data.replace(" ", "-")				
+				message = ((str(counter) + " ")+data).encode()
+				sendUDP_message(message, destinationIP)
+				counter = counter + 1
+			print("Finished ...")
 
 def waitUDP_message(test, timeout):
-        print("(UDP) Waiting Peer message ...")
-        timer_start = time.perf_counter()
-        socket_UDP = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        socket_UDP.bind((local_ip, UDP_PORT))
-        socket_UDP.settimeout(int(timeout))
-        packetCounter = 0
-        tmstpAUX = 0
-        while True:
-            try:
-                receivedData, addr = socket_UDP.recvfrom(1024)
-                if test == 1:
-                       dataFields = receivedData.decode().split()
-                       tmstpAUX += time.time()-float(dataFields[1])
-                print("(UDP) Received Packet " +str(packetCounter)+": "+str(receivedData))
-                packetCounter = packetCounter + 1
-            except:
-                if test == 1:
-                    print("Monitoring Finished - Latencia Media = " +
-                          str(tmstpAUX/packetCounter)+" ")
-                    sendTCP_Server(1, test, str(tmstpAUX/packetCounter))
-                    
-                elif test == 2:
-                    print("Monitoring Finished - Pacotes Recebidos = " +
-                          str(packetCounter)+" ")
-                    sendTCP_Server(1, test, str(packetCounter))
-                break
+		print("(UDP) Waiting Peer message ...")
+		timer_start = time.perf_counter()
+		socket_UDP = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		socket_UDP.bind((local_ip, UDP_PORT))
+		socket_UDP.settimeout(int(timeout))
+		packetCounter = 0
+		tmstpAUX = 0
+		while True:
+			try:
+				receivedData, addr = socket_UDP.recvfrom(1024)
+				if test == 1:
+					   dataFields = receivedData.decode().split()
+					   tmstpAUX += time.time()-float(dataFields[1])
+				print("(UDP) Received Packet " +str(packetCounter)+": "+str(receivedData))
+				packetCounter = packetCounter + 1
+			except:
+				if test == 1:
+					print("Monitoring Finished - Latencia Media = " +
+						  str(tmstpAUX/packetCounter)+" ")
+					socket_UDP.settimeout(None)
+					sendTCP_Server(1, test, str(tmstpAUX/packetCounter))
+					
+				elif test == 2:
+					print("Monitoring Finished - Pacotes Recebidos = " +
+						  str(packetCounter)+" ")
+					sendTCP_Server(1, test, str(packetCounter))
+				break
 
 def sendUDP_message(message, destinationIP):
-        print("(UDP) Sending for Peer "+str(destinationIP)+" ...")
-        socket_UDP = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-        timestamp = time.time()
-        udpMSG = message + str(timestamp).encode()
-        socket_UDP.sendto(udpMSG, (destinationIP, UDP_PORT))
-        print("(UDP) Sent +"+str(udpMSG)+" ...")
+		print("(UDP) Sending for Peer "+str(destinationIP)+" ...")
+		socket_UDP = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+		timestamp = time.time()
+		udpMSG = message + str(timestamp).encode()
+		socket_UDP.sendto(udpMSG, (destinationIP, UDP_PORT))
+		print("(UDP) Sent +"+str(udpMSG)+" ...")
 
 def sendTCP_Server(typeID, teste, resultado):
-        # |ID| TESTE | Resultado | Opcional |
-        message = str(typeID)+' '+str(teste)+' '+str(resultado)
-        print("Starting TCP connection with "+serverIP+" ...")
-        port = 5000
+		# |ID| TESTE | Resultado | Opcional |
+		message = str(typeID)+' '+str(teste)+' '+str(resultado)
+		print("Starting TCP connection with "+serverIP+" ...")
+		#port = 5000
 
-        # socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        # socket_TCP.connect((serverIP, port))
-        socket_TCP.send(message.encode())
-        socket_TCP.close()
+		# socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		# socket_TCP.connect((serverIP, port))
+		connection.send(message.encode())
 
 if __name__ == '__main__':
-        while 1:
-            server_message = waitServerRequest().decode()
-            print("Received from Server: "+server_message)
-            processRequest(server_message)
+		socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		socket_TCP.bind((local_ip, TCP_PORT))
+		
+		while True:
+			socket_TCP.listen(1)
+			connection, address = socket_TCP.accept()
+
+			server_message = waitServerRequest().decode()
+			print("Received from Server: "+server_message)
+			processRequest(server_message)
+			time.sleep(4)

--- a/version/v1.0/Peer_T.py
+++ b/version/v1.0/Peer_T.py
@@ -86,6 +86,7 @@ def waitUDP_message(test, timeout):
                     print("Monitoring Finished - Latencia Media = " +
                           str(tmstpAUX/packetCounter)+" ")
                     sendTCP_Server(1, test, str(tmstpAUX/packetCounter))
+                    
                 elif test == 2:
                     print("Monitoring Finished - Pacotes Recebidos = " +
                           str(packetCounter)+" ")
@@ -106,8 +107,8 @@ def sendTCP_Server(typeID, teste, resultado):
         print("Starting TCP connection with "+serverIP+" ...")
         port = 5000
 
-        socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        socket_TCP.connect((serverIP, port))
+        # socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # socket_TCP.connect((serverIP, port))
         socket_TCP.send(message.encode())
         socket_TCP.close()
 

--- a/version/v1.0/Server.py
+++ b/version/v1.0/Server.py
@@ -1,5 +1,7 @@
 import socket
 from threading import Thread
+import time
+import errno
 
 serverIP = '10.0.0.10' #socket.gethostbyname(socket.gethostname())
 gestorIP = '10.0.0.20'
@@ -22,71 +24,38 @@ def waitGestorRequest():
 			break
 		return gestorRequest 
 
-def activatePeers(request):
-	#|ID| TESTE | IP_Inicial | IP_Final | Opcional |
-	requestFields = request.split()
-	typeID = requestFields[0]
-	teste = requestFields[1]
-	peerA_IP = requestFields[2]
-	peerB_IP = requestFields[3]
-	optional = requestFields[4]
-
-	#|ID| TESTE | IP_Final | Opcional |
-	message = typeID+' '+teste+' '+peerB_IP+' '+optional
-	print("Starting TCP connection with "+peerA_IP+" ...")
-	port = 5000
-
-	socket_peerA = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	socket_peerA.connect((peerA_IP, port))
-	socket_peerA.send(message.encode())
-	socket_peerA.close()
-
-	print("Starting TCP connection with "+peerB_IP+" ...")
-	port = 5000
-
-	socket_peerB = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	socket_peerB.connect((peerB_IP, port))
-	socket_peerB.send(message.encode())
-	socket_peerB.close()
-
 
 class activatePeers_thread(Thread):
 
 	def __init__(self, peer_socket, message):
 		Thread.__init__(self)
-		self.peer_socket = peer_sockets
+		self.peer_socket = peer_socket
 		self.message = message
 
 	def run(self):
-		while True:
-			peer_socket.send(message.encode())
-			peer_socket.settimeout(10)
+
+		self.peer_socket.sendall(message.encode())
+		(peer_addr, peer_port) = self.peer_socket.getpeername()
+		while peer_addr == peerB_IP:
+			print("Entrou no while")
+			self.peer_socket.settimeout(20)
 			try: 
-				res = peer_socket.recv(1024)
-			except:
-				print("An exception ocurred, timeout?")
-				peer_socket.close()
-				break
-			#sendResult_Gestor(res)
-			print("-Monitorization Result: "+str(res))
-			break
-			
+				res = self.peer_socket.recv(1024).decode()
+			except socket.error as e:
+				err = e.args[0]
+				if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
+					sleep(1)
+					print("No data available")
+					continue
+				else:
+					print(e)
+					self.peer_socket.close()
+					break
+			sendResult_Gestor(res)
+			break	
 
-
-def waitPeerResult():
-	port = 5000
-
-	print("*** Server ***\n (TCP) Waiting Peer result on port "+str(port)+" ...")
-	socket_result = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-	socket_result.bind((serverIP, port))
-	socket_result.listen(1)
-	connection, address = socket_result.accept()
-	print("Connected from "+str(address))
-	while True:
-		peerResult = connection.recv(1024)
-		if not peerResult:
-			break
-		return peerResult 
+		self.peer_socket.shutdown(socket.SHUT_RDWR)
+		self.peer_socket.close()	
 
 def sendResult_Gestor(resultado):
 	port = 5005
@@ -94,31 +63,48 @@ def sendResult_Gestor(resultado):
 	print("(TCP) Connecting to Gestor "+str(gestorIP)+" ...")
 	socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 	socket_TCP.connect((gestorIP, port))
-	socket_TCP.send(resultado)
+	socket_TCP.send(resultado.encode())
 	socket_TCP.close()
 
 
 if __name__ == '__main__':
+
+	threads = []
+	
 	while 1:
 		gestorRequest = waitGestorRequest().decode()
 		print("Gestor Request: "+str(gestorRequest))
+
+		socket_peer_inicial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		socket_peer_final = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		
+
 		requestFields = gestorRequest.split()
 		typeID = requestFields[0]
 		teste = requestFields[1]
 		peerA_IP = requestFields[2]
 		peerB_IP = requestFields[3]
 		optional = requestFields[4]
+
+		socket_peer_inicial.connect((peerA_IP, TCP_PORT))
+		socket_peer_final.connect((peerB_IP, TCP_PORT))
+		
 		
 		message = typeID+' '+teste+' '+peerB_IP+' '+optional
 
-		socket_peer_inicial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		socket_peer_final = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-		socket_peer_inicial.connect((peerA_IP, TCP_PORT))
-		socket_peer_final.connect((peerB_IP, TCP_PORT))
 
 		thread_inicial = activatePeers_thread(socket_peer_inicial, message)
 		thread_final = activatePeers_thread(socket_peer_final, message)
+
+		thread_inicial.start()
+		thread_final.start()
+
+		threads.append(thread_inicial)
+		threads.append(thread_final)
+
+		for t in threads:
+			t.join()
+
 
 		#socket_peer.connect()
 		#activatePeers(gestorRequest)

--- a/version/v1.0/Server.py
+++ b/version/v1.0/Server.py
@@ -1,81 +1,127 @@
 import socket
+from threading import Thread
 
 serverIP = '10.0.0.10' #socket.gethostbyname(socket.gethostname())
 gestorIP = '10.0.0.20'
 
-def waitGestorRequest():
-    port = 5000
+TCP_PORT = 5000
 
-    print("*** Server ***\n Waiting on port "+str(port)+" ...")
-    socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_TCP.bind((serverIP, port))
-    socket_TCP.listen(1)
-    connection, address = socket_TCP.accept()
-    print("Connected from "+str(address))
-    #gestorIP = address[0]
-    while True:
-        gestorRequest = connection.recv(1024)
-        if not gestorRequest:
-            break
-        return gestorRequest 
+def waitGestorRequest():
+	port = 5000
+
+	print("*** Server ***\n Waiting on port "+str(port)+" ...")
+	socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	socket_TCP.bind((serverIP, port))
+	socket_TCP.listen(1)
+	connection, address = socket_TCP.accept()
+	print("Connected from "+str(address))
+	#gestorIP = address[0]
+	while True:
+		gestorRequest = connection.recv(1024)
+		if not gestorRequest:
+			break
+		return gestorRequest 
 
 def activatePeers(request):
-    #|ID| TESTE | IP_Inicial | IP_Final | Opcional |
-    requestFields = request.split()
-    typeID = requestFields[0]
-    teste = requestFields[1]
-    peerA_IP = requestFields[2]
-    peerB_IP = requestFields[3]
-    optional = requestFields[4]
+	#|ID| TESTE | IP_Inicial | IP_Final | Opcional |
+	requestFields = request.split()
+	typeID = requestFields[0]
+	teste = requestFields[1]
+	peerA_IP = requestFields[2]
+	peerB_IP = requestFields[3]
+	optional = requestFields[4]
 
-    #|ID| TESTE | IP_Final | Opcional |
-    message = typeID+' '+teste+' '+peerB_IP+' '+optional
-    print("Starting TCP connection with "+peerA_IP+" ...")
-    port = 5000
+	#|ID| TESTE | IP_Final | Opcional |
+	message = typeID+' '+teste+' '+peerB_IP+' '+optional
+	print("Starting TCP connection with "+peerA_IP+" ...")
+	port = 5000
 
-    socket_peerA = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_peerA.connect((peerA_IP, port))
-    socket_peerA.send(message.encode())
-    socket_peerA.close()
+	socket_peerA = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	socket_peerA.connect((peerA_IP, port))
+	socket_peerA.send(message.encode())
+	socket_peerA.close()
 
-    print("Starting TCP connection with "+peerB_IP+" ...")
-    port = 5000
+	print("Starting TCP connection with "+peerB_IP+" ...")
+	port = 5000
 
-    socket_peerB = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_peerB.connect((peerB_IP, port))
-    socket_peerB.send(message.encode())
-    socket_peerB.close()
+	socket_peerB = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	socket_peerB.connect((peerB_IP, port))
+	socket_peerB.send(message.encode())
+	socket_peerB.close()
+
+
+class activatePeers_thread(Thread):
+
+	def __init__(self, peer_socket, message):
+		Thread.__init__(self)
+		self.peer_socket = peer_sockets
+		self.message = message
+
+	def run(self):
+		while True:
+			peer_socket.send(message.encode())
+			peer_socket.settimeout(10)
+			try: 
+				res = peer_socket.recv(1024)
+			except:
+				print("An exception ocurred, timeout?")
+				peer_socket.close()
+				break
+			#sendResult_Gestor(res)
+			print("-Monitorization Result: "+str(res))
+			break
+			
+
 
 def waitPeerResult():
-    port = 5000
+	port = 5000
 
-    print("*** Server ***\n (TCP) Waiting Peer result on port "+str(port)+" ...")
-    socket_result = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_result.bind((serverIP, port))
-    socket_result.listen(1)
-    connection, address = socket_result.accept()
-    print("Connected from "+str(address))
-    while True:
-        peerResult = connection.recv(1024)
-        if not peerResult:
-            break
-        return peerResult 
+	print("*** Server ***\n (TCP) Waiting Peer result on port "+str(port)+" ...")
+	socket_result = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	socket_result.bind((serverIP, port))
+	socket_result.listen(1)
+	connection, address = socket_result.accept()
+	print("Connected from "+str(address))
+	while True:
+		peerResult = connection.recv(1024)
+		if not peerResult:
+			break
+		return peerResult 
 
 def sendResult_Gestor(resultado):
-    port = 5005
+	port = 5005
 
-    print("(TCP) Connecting to Gestor "+str(gestorIP)+" ...")
-    socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    socket_TCP.connect((gestorIP, port))
-    socket_TCP.send(resultado)
-    socket_TCP.close()
+	print("(TCP) Connecting to Gestor "+str(gestorIP)+" ...")
+	socket_TCP = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+	socket_TCP.connect((gestorIP, port))
+	socket_TCP.send(resultado)
+	socket_TCP.close()
 
 
 if __name__ == '__main__':
-    while 1:
-	    gestorRequest = waitGestorRequest().decode()
-	    print("Gestor Request: "+str(gestorRequest))
-	    activatePeers(gestorRequest)
-	    monitorizationResult = waitPeerResult()
-	    print("Monitorization Result: "+str(monitorizationResult))
-	    sendResult_Gestor(monitorizationResult)
+	while 1:
+		gestorRequest = waitGestorRequest().decode()
+		print("Gestor Request: "+str(gestorRequest))
+		
+		requestFields = gestorRequest.split()
+		typeID = requestFields[0]
+		teste = requestFields[1]
+		peerA_IP = requestFields[2]
+		peerB_IP = requestFields[3]
+		optional = requestFields[4]
+		
+		message = typeID+' '+teste+' '+peerB_IP+' '+optional
+
+		socket_peer_inicial = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		socket_peer_final = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+		socket_peer_inicial.connect((peerA_IP, TCP_PORT))
+		socket_peer_final.connect((peerB_IP, TCP_PORT))
+
+		thread_inicial = activatePeers_thread(socket_peer_inicial, message)
+		thread_final = activatePeers_thread(socket_peer_final, message)
+
+		#socket_peer.connect()
+		#activatePeers(gestorRequest)
+		#monitorizationResult = waitPeerResult()
+		#print("Monitorization Result: "+str(monitorizationResult))
+		#sendResult_Gestor(monitorizationResult)


### PR DESCRIPTION
Servidor abre duas threads uma para comunicar com cada peer interveniente no teste, recebe resultado apenas do peer final. Operação continua.